### PR TITLE
Fix duplicate project time merging

### DIFF
--- a/README.Developer Guide.md
+++ b/README.Developer Guide.md
@@ -492,6 +492,16 @@ The application follows RESTful principles with working time-scoped UIProjectTim
 
 The consolidator is the core abstraction layer that allows the frontend to work with simple task durations while maintaining compatibility with Timr's time slot requirements.
 
+### Time Slot Handling Overview
+
+Timr stores project times as individual time slots. Users, however, usually think in
+terms of total time spent on a task during a working time. The `ProjectTimeConsolidator`
+merges all slots of the same task into a single `UIProjectTime` object and generates
+new sequential time slots when saving changes. Duplicate time slots returned from the
+API are removed so that exactly one project time per task remains after an update.
+Slots are created in descending order of the task names and may overlap if the working
+time is shorter than the combined duration.
+
 ## Key Design Patterns
 
 ### Composite Key Pattern


### PR DESCRIPTION
## Summary
- merge duplicate project times per task before updating
- document time slot logic in the developer guide
- clarify sequential slot calculation in code comments
- test that duplicates are removed during differential updates

## Testing
- `npm test --silent`
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_68483f455da0832cb18de83a258b3cde