### PR TITLE
Handle open working times

### DIFF
--- a/tests/test_app_comprehensive.py
+++ b/tests/test_app_comprehensive.py
@@ -472,7 +472,7 @@ class TestAppUtilityFunctions(unittest.TestCase):
 
     def test_parse_date_valid_formats(self):
         """Test parse_date with valid date formats"""
-        from app import parse_date
+        from utils import parse_date
         
         # Test ISO format
         result = parse_date('2025-04-01')
@@ -488,7 +488,7 @@ class TestAppUtilityFunctions(unittest.TestCase):
 
     def test_parse_date_invalid_formats(self):
         """Test parse_date with invalid date formats"""
-        from app import parse_date
+        from utils import parse_date
         
         # Test invalid format
         result = parse_date('invalid-date')
@@ -504,7 +504,7 @@ class TestAppUtilityFunctions(unittest.TestCase):
 
     def test_parse_time_valid_formats(self):
         """Test parse_time with valid time formats"""
-        from app import parse_time
+        from utils import parse_time
         
         # Test HH:MM format (the main format supported)
         result = parse_time('14:30')
@@ -520,7 +520,7 @@ class TestAppUtilityFunctions(unittest.TestCase):
 
     def test_parse_time_invalid_formats(self):
         """Test parse_time with invalid time formats"""
-        from app import parse_time
+        from utils import parse_time
         
         # Test invalid format
         result = parse_time('invalid-time')
@@ -536,7 +536,7 @@ class TestAppUtilityFunctions(unittest.TestCase):
 
     def test_combine_datetime(self):
         """Test combine_datetime function"""
-        from app import combine_datetime
+        from utils import combine_datetime
         import datetime
         
         date_obj = datetime.date(2025, 4, 1)
@@ -552,7 +552,7 @@ class TestAppUtilityFunctions(unittest.TestCase):
 
     def test_format_duration(self):
         """Test format_duration function"""
-        from app import format_duration
+        from utils import format_duration
         
         # Test basic formatting
         self.assertEqual(format_duration(90), "1h 30m")

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -1,103 +1,15 @@
 import unittest
-import datetime
 import json
 from unittest.mock import patch, MagicMock
-from app import parse_date, parse_time, combine_datetime, format_duration, get_working_times, get_project_times
-from config import DATE_FORMAT, TIME_FORMAT
-from timr_api import TimrApi
 from timr_utils import UIProjectTime
-
-class TestAppUtils(unittest.TestCase):
-    """Test utilities from app.py"""
-    
-    def test_parse_date(self):
-        """Test that date parsing works with different formats."""
-        # Test standard format (YYYY-MM-DD)
-        date_str = "2025-05-01"
-        date = parse_date(date_str)
-        self.assertIsNotNone(date)
-        self.assertEqual(date.year, 2025)
-        self.assertEqual(date.month, 5)
-        self.assertEqual(date.day, 1)
-        
-        # Test ISO format with time
-        date_str = "2025-05-01T10:30:00Z"
-        date = parse_date(date_str)
-        self.assertIsNotNone(date)
-        self.assertEqual(date.year, 2025)
-        self.assertEqual(date.month, 5)
-        self.assertEqual(date.day, 1)
-        
-        # Test invalid format
-        date_str = "05/01/2025"
-        date = parse_date(date_str)
-        self.assertIsNone(date)
-        
-        # Test None
-        date = parse_date(None)
-        self.assertIsNone(date)
-    
-    def test_parse_time(self):
-        """Test that time parsing works with different formats."""
-        # Test standard format (HH:MM)
-        time_str = "10:30"
-        time = parse_time(time_str)
-        self.assertIsNotNone(time)
-        self.assertEqual(time.hour, 10)
-        self.assertEqual(time.minute, 30)
-        
-        # Test ISO format with date
-        time_str = "2025-05-01T10:30:00Z"
-        time = parse_time(time_str)
-        self.assertIsNotNone(time)
-        self.assertEqual(time.hour, 10)
-        self.assertEqual(time.minute, 30)
-        
-        # Test invalid format
-        time_str = "10:30 AM"
-        time = parse_time(time_str)
-        self.assertIsNone(time)
-        
-        # Test None
-        time = parse_time(None)
-        self.assertIsNone(time)
-    
-    def test_combine_datetime(self):
-        """Test combining date and time."""
-        date = datetime.date(2025, 5, 1)
-        time = datetime.time(10, 30)
-        dt = combine_datetime(date, time)
-        self.assertEqual(dt.year, 2025)
-        self.assertEqual(dt.month, 5)
-        self.assertEqual(dt.day, 1)
-        self.assertEqual(dt.hour, 10)
-        self.assertEqual(dt.minute, 30)
-    
-    def test_format_duration(self):
-        """Test formatting duration in minutes to hours and minutes."""
-        # Test 1 hour
-        duration = format_duration(60)
-        self.assertEqual(duration, "1h 0m")
-        
-        # Test 1 hour and 30 minutes
-        duration = format_duration(90)
-        self.assertEqual(duration, "1h 30m")
-        
-        # Test just minutes
-        duration = format_duration(45)
-        self.assertEqual(duration, "0h 45m")
-        
-        # Test multiple hours
-        duration = format_duration(150)
-        self.assertEqual(duration, "2h 30m")
+from app import app, get_working_times, get_project_times
 
 class TestApiEndpoints(unittest.TestCase):
     """Test the API endpoints in app.py"""
     
     def setUp(self):
-        from app import app
-        self.app = app
         self.app_context = app.app_context()
+        self.app = app
         self.app_context.push()
         self.request_context = app.test_request_context()
         self.request_context.push()
@@ -111,7 +23,6 @@ class TestApiEndpoints(unittest.TestCase):
     @patch('app.session')
     def test_get_working_times_with_date(self, mock_session, mock_timr_api, mock_get_current_user):
         """Test that get_working_times filters by date correctly."""
-        from app import get_working_times
         
         # Configure the mock timr_api instance
         mock_timr_api.get_working_times.return_value = [
@@ -145,7 +56,6 @@ class TestApiEndpoints(unittest.TestCase):
             
             # Verify the response is a valid JSON response
             # Flask test client returns a Response object or a tuple (response, status_code)
-            import json
             
             if isinstance(result, tuple):
                 response, status_code = result
@@ -168,7 +78,6 @@ class TestApiEndpoints(unittest.TestCase):
     @patch('app.session')
     def test_get_working_times_with_invalid_date(self, mock_session, mock_timr_api, mock_get_current_user):
         """Test that get_working_times handles invalid dates properly."""
-        from app import get_working_times
         
         # Mock the request with invalid date
         with self.app.test_request_context('/api/working-times?date=invalid-date'):
@@ -186,7 +95,6 @@ class TestApiEndpoints(unittest.TestCase):
             
             # Verify that an error response was returned
             # Flask test client returns a Response object or a tuple (response, status_code)
-            import json
             
             if isinstance(result, tuple):
                 response, status_code = result
@@ -210,7 +118,6 @@ class TestApiEndpoints(unittest.TestCase):
     @patch('app.session')
     def test_get_project_times_response_structure(self, mock_session, mock_consolidator, mock_timr_api, mock_get_current_user):
         """Test that get_project_times returns the correct consolidated_project_times structure."""
-        from app import get_project_times
         
         # Create test data
         mock_working_time = {'id': 'wt1', 'start': '2025-05-01T09:00:00Z', 'end': '2025-05-01T17:00:00Z'}

--- a/tests/test_timr_api.py
+++ b/tests/test_timr_api.py
@@ -1,6 +1,7 @@
 import unittest
 import datetime
 import pytz
+from unittest.mock import patch
 from timr_api import TimrApi
 
 
@@ -62,6 +63,22 @@ class TestTimrApi(unittest.TestCase):
         dt_str = "2025-05-01"
         formatted = self.api._format_date_for_query(dt_str)
         self.assertEqual(formatted, "2025-05-01")
+
+    def test_get_project_times_open_working_time(self):
+        """_get_project_times_in_work_time handles recording working times."""
+        working_time = {
+            "start": "2025-04-01T09:00:00Z",
+            "end": None,
+        }
+
+        sample_project_times = [
+            {"start": "2025-04-01T09:30:00Z", "end": "2025-04-01T10:00:00Z"}
+        ]
+
+        with patch.object(self.api, "get_project_times", return_value=sample_project_times) as mock_get:
+            result = self.api._get_project_times_in_work_time(working_time)
+            self.assertEqual(len(result), 1)
+            mock_get.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,124 @@
+import unittest
+import datetime
+from utils import (
+    parse_date,
+    parse_time,
+    combine_datetime,
+    format_duration,
+    parse_iso_datetime,
+)
+
+class TestUtilsFunctions(unittest.TestCase):
+    """Test helpers in utils.py."""
+    
+    def test_parse_date(self):
+        """Test that date parsing works with different formats."""
+        # Test standard format (YYYY-MM-DD)
+        date_str = "2025-05-01"
+        date = parse_date(date_str)
+        self.assertIsNotNone(date)
+        self.assertEqual(date.year, 2025)
+        self.assertEqual(date.month, 5)
+        self.assertEqual(date.day, 1)
+        
+        # Test ISO format with time
+        date_str = "2025-05-01T10:30:00Z"
+        date = parse_date(date_str)
+        self.assertIsNotNone(date)
+        self.assertEqual(date.year, 2025)
+        self.assertEqual(date.month, 5)
+        self.assertEqual(date.day, 1)
+        
+        # Test invalid format
+        date_str = "05/01/2025"
+        date = parse_date(date_str)
+        self.assertIsNone(date)
+        
+        # Test None
+        date = parse_date(None)
+        self.assertIsNone(date)
+    
+    def test_parse_time(self):
+        """Test that time parsing works with different formats."""
+        # Test standard format (HH:MM)
+        time_str = "10:30"
+        time = parse_time(time_str)
+        self.assertIsNotNone(time)
+        self.assertEqual(time.hour, 10)
+        self.assertEqual(time.minute, 30)
+        
+        # Test ISO format with date
+        time_str = "2025-05-01T10:30:00Z"
+        time = parse_time(time_str)
+        self.assertIsNotNone(time)
+        self.assertEqual(time.hour, 10)
+        self.assertEqual(time.minute, 30)
+        
+        # Test invalid format
+        time_str = "10:30 AM"
+        time = parse_time(time_str)
+        self.assertIsNone(time)
+        
+        # Test None
+        time = parse_time(None)
+        self.assertIsNone(time)
+    
+    def test_combine_datetime(self):
+        """Test combining date and time."""
+        date = datetime.date(2025, 5, 1)
+        time = datetime.time(10, 30)
+        dt = combine_datetime(date, time)
+        self.assertEqual(dt.year, 2025)
+        self.assertEqual(dt.month, 5)
+        self.assertEqual(dt.day, 1)
+        self.assertEqual(dt.hour, 10)
+        self.assertEqual(dt.minute, 30)
+    
+    def test_format_duration(self):
+        """Test formatting duration in minutes to hours and minutes."""
+        # Test 1 hour
+        duration = format_duration(60)
+        self.assertEqual(duration, "1h 0m")
+        
+        # Test 1 hour and 30 minutes
+        duration = format_duration(90)
+        self.assertEqual(duration, "1h 30m")
+        
+        # Test just minutes
+        duration = format_duration(45)
+        self.assertEqual(duration, "0h 45m")
+        
+        # Test multiple hours
+        duration = format_duration(150)
+        self.assertEqual(duration, "2h 30m")
+
+    def test_parse_iso_datetime_valid(self):
+        """parse_iso_datetime parses ISO strings with Z suffix and offsets."""
+        dt = parse_iso_datetime("2025-05-01T10:00:00Z")
+        self.assertEqual(
+            dt,
+            datetime.datetime(2025, 5, 1, 10, 0, tzinfo=datetime.timezone.utc),
+        )
+
+        offset_dt = parse_iso_datetime("2025-05-01T11:30:00+02:00")
+        self.assertEqual(
+            offset_dt,
+            datetime.datetime(
+                2025,
+                5,
+                1,
+                11,
+                30,
+                tzinfo=datetime.timezone(datetime.timedelta(hours=2)),
+            ),
+        )
+
+    def test_parse_iso_datetime_invalid(self):
+        """Invalid or None input returns None."""
+        self.assertIsNone(parse_iso_datetime(None))
+        self.assertIsNone(parse_iso_datetime("invalid"))
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/timr_utils.py
+++ b/timr_utils.py
@@ -6,6 +6,7 @@ Copyright (c) 2025 Ohrner IT GmbH
 Licensed under the MIT License
 """
 
+import json
 import logging
 from datetime import datetime, timedelta
 from typing import List, Dict, Any, Optional, Set, Tuple, Union
@@ -70,7 +71,6 @@ class UIProjectTime:
         Returns:
             str: JSON string representation of this UIProjectTime
         """
-        import json
         return json.dumps(self.to_dict())
 
     def to_dict(self) -> Dict[str, Any]:

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,66 @@
+import logging
+from datetime import datetime
+from config import DATE_FORMAT, TIME_FORMAT
+
+logger = logging.getLogger(__name__)
+
+def parse_iso_datetime(value):
+    """Safely parse an ISO 8601 datetime string.
+
+    Returns None if the value is None or invalid.
+    """
+    if not value:
+        return None
+    try:
+        if isinstance(value, str) and value.endswith('Z'):
+            value = value.replace('Z', '+00:00')
+        return datetime.fromisoformat(value)
+    except (ValueError, AttributeError, TypeError):
+        logger.error("Invalid ISO datetime provided: %s", value)
+        return None
+
+def parse_date(date_str):
+    """Parse a date string into a datetime.date object."""
+    if not date_str:
+        return None
+    formats = [DATE_FORMAT, "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%SZ"]
+    for fmt in formats:
+        try:
+            if fmt == DATE_FORMAT:
+                return datetime.strptime(date_str, fmt).date()
+            else:
+                if date_str.endswith('Z'):
+                    date_str = date_str[:-1] + '+00:00'
+                dt = datetime.strptime(date_str, fmt)
+                return dt.date()
+        except ValueError:
+            continue
+    return None
+
+def parse_time(time_str):
+    """Parse a time string into a datetime.time object."""
+    if not time_str:
+        return None
+    formats = [TIME_FORMAT, "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%SZ"]
+    for fmt in formats:
+        try:
+            if fmt == TIME_FORMAT:
+                return datetime.strptime(time_str, fmt).time()
+            else:
+                if time_str.endswith('Z'):
+                    time_str = time_str[:-1] + '+00:00'
+                dt = datetime.strptime(time_str, fmt)
+                return dt.time()
+        except ValueError:
+            continue
+    return None
+
+def combine_datetime(date_obj, time_obj):
+    """Combine date and time objects into a datetime."""
+    return datetime.combine(date_obj, time_obj)
+
+def format_duration(minutes):
+    """Format duration in minutes to hours and minutes."""
+    hours = minutes // 60
+    remaining_mins = minutes % 60
+    return f"{hours}h {remaining_mins}m"


### PR DESCRIPTION
## Summary
- avoid crashing when working time end time is missing
- centralise ISO datetime parsing
- skip overlap checks for incomplete records
- test editing tasks on a recording working time
- support retrieving project times when end time is absent
- refactor utils tests and fix internal imports

## Testing
- `./run_all_tests.sh`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ad9f1eac0832c8c486a01f126b39c