### PR TITLE
Fix environment variable name in testing guide

### DIFF
--- a/doc/README.Testing Guide.md
+++ b/doc/README.Testing Guide.md
@@ -77,7 +77,7 @@ Unit tests with mocks are useful for testing code in isolation, but they rely on
 
 1. Set environment variables for Timr.com credentials:
    ```bash
-   export TIMR_USERNAME=your_username
+   export TIMR_USER=your_username
    export TIMR_PASSWORD=your_password
    ```
 

--- a/doc/README.Testing Guide.md
+++ b/doc/README.Testing Guide.md
@@ -73,7 +73,7 @@ Unit tests with mocks are useful for testing code in isolation, but they rely on
 
 ### Running Integration Tests
 
-**WARNING**: Integration tests make real changes to your Timr.com account! They create and delete working times and project times. Tests use future dates to minimize conflicts and clean up after themselves, but use with caution.
+**WARNING**: Integration tests make real changes to your Timr.com account! They create and delete working times and project times. The tests use yesterday's date to avoid conflicts and stay within API restrictions, but use with caution.
 
 1. Set environment variables for Timr.com credentials:
    ```bash

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 # Define test credentials - these can be overridden by environment variables
-TEST_USERNAME = os.environ.get("TIMR_USERNAME", "test_user")
+TEST_USERNAME = os.environ.get("TIMR_USER", "test_user")
 TEST_PASSWORD = os.environ.get("TIMR_PASSWORD", "test_password")
 
 # Define test database (use in-memory SQLite for unit tests)


### PR DESCRIPTION
## Summary
- update testing guide to use `TIMR_USER` for integration tests

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684dfd027010832c8ab75ce268488d90